### PR TITLE
Update Ray-Tracer to use the new TornadoVM data types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/*
+target/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/*
 target/*
+*.env

--- a/README.md
+++ b/README.md
@@ -35,10 +35,18 @@ All TornadoVM SDKs are available on the [SDKMAN! TornadoVM page](https://sdkman.
 sdk install tornadovm
 ```
 
-- Use JDK 21
+- Use JDK 21 or JDK 25
+
+TornadoVM-Ray-Tracer builds and runs with **JDK 21** or **JDK 25**, as long as the installed TornadoVM distribution matches the JDK in use (TornadoVM ships separate `jdk21` and `jdk25` builds). The Maven build auto-detects the running JDK and selects the matching TornadoVM dependency:
+
+| JDK | Maven profile (auto-activated) | TornadoVM dependency |
+|-----|-------------------------------|----------------------|
+| 21.x | `jdk21` | `tornado-api` `*-jdk21` |
+| 25.0.2+ | `jdk25` | `tornado-api` `*-jdk25` |
 
 ```bash
-sdk install java 21.0.2-open 
+sdk install java 21.0.2-open    # for JDK 21
+sdk install java 25.0.2-open    # for JDK 25
 ```
 
 - Download the JavaFX SDK for your system from: [JavaFX downloads](https://gluonhq.com/products/javafx/). You will need
@@ -66,6 +74,12 @@ source sources.env
 
 ```bash
 mvn clean install
+```
+
+The JDK profile is selected automatically from the JDK running Maven. To force a specific variant regardless of the running JDK:
+
+```bash
+mvn clean install -P jdk21,'!jdk25'   # force the JDK 21 variant
 ```
 
 5. Run TornadoVM-Ray-Tracer:

--- a/README.md
+++ b/README.md
@@ -25,19 +25,21 @@ git clone https://github.com/Vinhixus/TornadoVM-Ray-Tracer.git
 
 2. Install dependencies:
 
-- Install TornadoVM. The following example builds TornadoVM with OpenJDK 11 and OpenCL:
+- Install TornadoVM (via SDKMAN!)
+
+TornadoVM is distributed through our [**official website**](https://www.tornadovm.org/downloads) and **SDKMAN!**. Install a version that matches your OS, architecture, and accelerator backend.
+
+All TornadoVM SDKs are available on the [SDKMAN! TornadoVM page](https://sdkman.io/sdks/tornadovm/).
 
 ```bash
-git clone https://github.com/beehive-lab/TornadoVM.git 
-cd TornadoVM
-./scripts/tornadoVMInstaller.sh --jdk11 --opencl
-source source.sh
-cd ..
+sdk install tornadovm
 ```
 
-**If you cannot build TornadoVM with the installer, try
-the [manual installation](https://github.com/beehive-lab/TornadoVM/blob/master/assembly/src/docs/12_INSTALL_WITH_JDK11_PLUS.md)
-.**
+- Use JDK 21
+
+```bash
+sdk install java 21.0.2-open 
+```
 
 - Download the JavaFX SDK for your system from: [JavaFX downloads](https://gluonhq.com/products/javafx/). You will need
   the path of the JavaFX SDK for Step 3.
@@ -52,10 +54,6 @@ vim sources.env
 export TORNADO_RAY_TRACER_ROOT="${PWD}"
 export PATH="${PATH}:${TORNADO_RAY_TRACER_ROOT=}/bin"
 export JAVAFX_SDK=<path to JavaFX>/javafx-sdk-18/
-export TORNADO_ROOT=<path to TornadoVM>
-export PATH="${PATH}:${TORNADO_ROOT}/bin/bin/"
-export TORNADO_SDK=${TORNADO_ROOT}/bin/sdk
-export JAVA_HOME=${TORNADO_ROOT}/TornadoVM-OpenJDK11/jdk-11.0.13+8
 ```
 
 Load the environment:

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -7,7 +7,7 @@ JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.cont
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
 	echo "Running TornadoVM Ray Tracer with GUI..."
-	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}"  com.vinhderful.raytracer.App
+	tornado --module-path="${JFLAGS}" --printKernel --threadInfo --classpath="${CLASSPATH}:${JARS}"  com.vinhderful.raytracer.App
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -7,7 +7,7 @@ JFLAGS=".:${JAVAFX_SDK}/lib --add-modules ALL-SYSTEM,javafx.controls,javafx.grap
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
 	echo "Running TornadoVM Ray Tracer with GUI..."
-	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --debug --printKernel --threadInfo com.vinhderful.raytracer.App
+	tornado -ea --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --debug --printKernel --threadInfo com.vinhderful.raytracer.App
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."
@@ -18,7 +18,7 @@ elif [ "$1" == "regression" ]; then
 	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --jvm="-Dskip.sequential=True " com.vinhderful.raytracer.Benchmark 
 else
 	echo "Please run:"
-	echo "tornadovm-ray-tracer               for the gui version or"
-	echo "tornadovm-ray-tracer benchmark     for the benchmark mode."
-	echo "tornadovm-ray-tracer regression    for regression tests (it skips sequential execution)"
+	echo "  tornadovm-ray-tracer               for the gui version or"
+	echo "  tornadovm-ray-tracer benchmark     for the benchmark mode."
+	echo "  tornadovm-ray-tracer regression    for regression tests (it skips sequential execution)"
 fi

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -7,11 +7,11 @@ JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.cont
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
 	echo "Running TornadoVM Ray Tracer with GUI..."
-	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --debug --printKernel --threadInfo com.vinhderful.raytracer.App
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}"  com.vinhderful.raytracer.App
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."
-	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}"  --debug --printKernel --threadInfo com.vinhderful.raytracer.Benchmark
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}"  com.vinhderful.raytracer.Benchmark
 elif [ "$1" == "regression" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -15,7 +15,7 @@ elif [ "$1" == "benchmark" ]; then
 elif [ "$1" == "regression" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."
-	tornado --module-path="${JFLAGS}" -classpath="${CLASSPATH}:${JARS}" --jvm="-Dskip.sequential=True " com.vinhderful.raytracer.Benchmark 
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --jvm="-Dskip.sequential=True " com.vinhderful.raytracer.Benchmark 
 else
 	echo "Please run:"
 	echo "tornadovm-ray-tracer               for the gui version or"

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -2,7 +2,7 @@
 
 JARS=$(echo ${TORNADO_RAY_TRACER_ROOT}/target/classes | tr ' ' ':')
 
-JFLAGS=".:${JAVAFX_SDK}/lib --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false"
+JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false"
 
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
@@ -11,7 +11,7 @@ if [ $# -eq 0 ]; then
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."
-	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" com.vinhderful.raytracer.Benchmark
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}"  --debug --printKernel --threadInfo com.vinhderful.raytracer.Benchmark
 elif [ "$1" == "regression" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -7,7 +7,7 @@ JFLAGS=".:${JAVAFX_SDK}/lib --add-modules ALL-SYSTEM,javafx.controls,javafx.grap
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
 	echo "Running TornadoVM Ray Tracer with GUI..."
-	tornado -ea --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --debug --printKernel --threadInfo com.vinhderful.raytracer.App
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --debug --printKernel --threadInfo com.vinhderful.raytracer.App
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -2,20 +2,20 @@
 
 JARS=$(echo ${TORNADO_RAY_TRACER_ROOT}/target/classes | tr ' ' ':')
 
-JFLAGS="--module-path .:${JAVAFX_SDK}/lib --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false"
+JFLAGS=".:${JAVAFX_SDK}/lib --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false"
 
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
 	echo "Running TornadoVM Ray Tracer with GUI..."
-	tornado ${JFLAGS} -classpath ${CLASSPATH}:${JARS} --debug --threadInfo com.vinhderful.raytracer.App
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" --debug --printKernel --threadInfo com.vinhderful.raytracer.App
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."
-	tornado ${JFLAGS} -classpath ${CLASSPATH}:${JARS} com.vinhderful.raytracer.Benchmark
+	tornado --module-path="${JFLAGS}" --classpath="${CLASSPATH}:${JARS}" com.vinhderful.raytracer.Benchmark
 elif [ "$1" == "regression" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."
-	tornado ${JFLAGS} -classpath ${CLASSPATH}:${JARS} -Dskip.sequential=True com.vinhderful.raytracer.Benchmark 
+	tornado --module-path="${JFLAGS}" -classpath="${CLASSPATH}:${JARS}" --jvm="-Dskip.sequential=True " com.vinhderful.raytracer.Benchmark 
 else
 	echo "Please run:"
 	echo "tornadovm-ray-tracer               for the gui version or"

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -7,7 +7,7 @@ JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.cont
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"
 	echo "Running TornadoVM Ray Tracer with GUI..."
-	tornado --module-path="${JFLAGS}" --printKernel --threadInfo --classpath="${CLASSPATH}:${JARS}"  com.vinhderful.raytracer.App
+	tornado --module-path="${JFLAGS}" --threadInfo --printKernel --classpath="${CLASSPATH}:${JARS}"  com.vinhderful.raytracer.App
 elif [ "$1" == "benchmark" ]; then
 	echo "-----------------------------------------"
 	echo "Running TornadoVM Ray Tracer benchmark mode..."

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -2,7 +2,7 @@
 
 JARS=$(echo ${TORNADO_RAY_TRACER_ROOT}/target/classes | tr ' ' ':')
 
-JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false"
+JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false -Dtornado.compiler.fullInlining=True"
 
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"

--- a/bin/tornadovm-ray-tracer
+++ b/bin/tornadovm-ray-tracer
@@ -2,7 +2,9 @@
 
 JARS=$(echo ${TORNADO_RAY_TRACER_ROOT}/target/classes | tr ' ' ':')
 
-JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false -Dtornado.compiler.fullInlining=True"
+# MethodInlineBailoutLimit: Graal's inlining walker gives up after 1000 exploration steps by
+# default; on JDK 25 the render kernel's call tree needs far more, leaving invokes un-inlined.
+JFLAGS=".:${JAVAFX_SDK}/lib -Xms18G -Xmx18G --add-modules ALL-SYSTEM,javafx.controls,javafx.graphics,javafx.fxml -Dprism.vsync=false -Dtornado.compiler.fullInlining=True -Djdk.graal.MethodInlineBailoutLimit=1000000"
 
 if [ $# -eq 0 ]; then
 	echo "------------------------------------"

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.1.0-dev</version>
+            <version>1.1.1-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.7-dev</version>
+            <version>1.0.8-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.6-dev</version>
+            <version>1.0.7-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.9</version>
+            <version>1.0.11-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.8-dev</version>
+            <version>1.0.9-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.11-dev</version>
+            <version>1.1.0-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.9-dev</version>
+            <version>1.0.9</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15</version>
+            <version>0.15.1-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.2-dev</version>
+            <version>1.0.3</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15-dev</version>
+            <version>0.15</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.16-dev</version>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15.1</version>
+            <version>0.15.2-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0</version>
+            <version>1.0.1-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.1-dev</version>
+            <version>1.0.2-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15.2-dev</version>
+            <version>0.16-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.14-dev</version>
+            <version>0.15-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15.2-dev</version>
+            <version>0.16-dev</version>
         </dependency>
     </dependencies>
 
@@ -40,8 +40,26 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                    <!-- Enable preview feature -->
+                    <compilerArgs>
+                        <arg>--enable-preview</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15.1-dev</version>
+            <version>0.15.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,22 +16,22 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
-            <version>18</version>
+            <version>21</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>18</version>
+            <version>21</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>18</version>
+            <version>21</version>
         </dependency>
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.4-dev</version>
+            <version>1.0.6-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.1.1-dev</version>
+            <version>1.1.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,22 @@
                 <jdk.version.suffix>-jdk21-dev</jdk.version.suffix>
                 <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <!-- The FFM API backing TornadoVM's native arrays is a preview API in
+                                 Java 21 (final since Java 22), so the jdk21 TornadoVM jars are
+                                 compiled with enable-preview and consumers must compile with it too. -->
+                            <compilerArgs>
+                                <arg>--enable-preview</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <!-- ─── JDK 25 ───────────────────────────────────────────────────────────

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.github.beehive-lab</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>2.2.0</version>
+            <version>4.0.2-jdk21-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
             <version>21</version>
         </dependency>
         <dependency>
-            <groupId>tornado</groupId>
+            <groupId>io.github.beehive-lab</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>1.1.2-dev</version>
+            <version>2.0.1-dev</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.github.beehive-lab</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>2.0.1-dev</version>
+            <version>2.2.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.github.beehive-lab</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>4.0.2-jdk21-dev</version>
+            <version>${tornadovm.version}</version>
         </dependency>
     </dependencies>
 
@@ -40,8 +40,12 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <tornadovm.base.version>4.0.2</tornadovm.base.version>
+        <!-- Defaults (overridden by the JDK profiles below) -->
+        <jdk.version.suffix>-jdk25-dev</jdk.version.suffix>
+        <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+        <maven.compiler.release>25</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
@@ -49,17 +53,42 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                    <!-- Enable preview feature -->
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- ─── JDK 21 ───────────────────────────────────────────────────────────
+             Auto-activates for JDK 21.x builds.
+             TornadoVM: ${tornadovm.base.version}-jdk21-dev
+        ─────────────────────────────────────────────────────────────────────── -->
+        <profile>
+            <id>jdk21</id>
+            <activation><jdk>[21,25)</jdk></activation>
+            <properties>
+                <maven.compiler.release>21</maven.compiler.release>
+                <jdk.version.suffix>-jdk21-dev</jdk.version.suffix>
+                <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+            </properties>
+        </profile>
+
+        <!-- ─── JDK 25 ───────────────────────────────────────────────────────────
+             Auto-activates for JDK 25.0.2+ builds (minimum required version).
+             TornadoVM: ${tornadovm.base.version}-jdk25-dev
+        ─────────────────────────────────────────────────────────────────────── -->
+        <profile>
+            <id>jdk25</id>
+            <activation><jdk>[25.0.2,)</jdk></activation>
+            <properties>
+                <maven.compiler.release>25</maven.compiler.release>
+                <jdk.version.suffix>-jdk25-dev</jdk.version.suffix>
+                <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/com/vinhderful/raytracer/App.java
+++ b/src/main/java/com/vinhderful/raytracer/App.java
@@ -18,15 +18,15 @@
  */
 package com.vinhderful.raytracer;
 
+import java.io.IOException;
+import java.util.Objects;
+
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-
-import java.io.IOException;
-import java.util.Objects;
 
 /**
  * Java-based Ray Tracer using JavaFX
@@ -36,7 +36,8 @@ public class App extends Application {
     /**
      * Launch application window
      *
-     * @param args program arguments
+     * @param args
+     *     program arguments
      */
     public static void main(String[] args) {
         launch(args);
@@ -45,7 +46,8 @@ public class App extends Application {
     /**
      * Initialise application window
      *
-     * @param stage the stage to show
+     * @param stage
+     *     the stage to show
      */
     @Override
     public void start(Stage stage) {
@@ -58,7 +60,8 @@ public class App extends Application {
         }
 
         Scene scene = null;
-        if (root != null) scene = new Scene(root);
+        if (root != null)
+            scene = new Scene(root);
 
         stage.setTitle("TornadoVM Ray Tracer");
         stage.getIcons().add(new Image(Objects.requireNonNull(App.class.getResourceAsStream("icon.png"))));

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -106,7 +106,7 @@ public class Benchmark {
         WorkerGrid worker = new WorkerGrid2D(WIDTH, HEIGHT);
         worker.setLocalWork(16, 16, 1);
         GridScheduler grid = new GridScheduler();
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         TornadoExecutionPlan rayTracingPlan = new TornadoExecutionPlan(ts.snapshot());
         rayTracingPlan.withGridScheduler(grid).execute();

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -18,6 +18,7 @@
  */
 package com.vinhderful.raytracer;
 
+import java.lang.foreign.Arena;
 import java.util.ArrayList;
 import java.util.Set;
 
@@ -48,10 +49,10 @@ import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 @SuppressWarnings("PrimitiveArrayArgumentToVarargsMethod")
 public class Benchmark {
 
-    private static final boolean SKIP_SEQUENTIAL = Boolean.parseBoolean(System.getProperty("skip.sequential", "True"));
+    private static final boolean SKIP_SEQUENTIAL = Boolean.parseBoolean(System.getProperty("skip.sequential", "False"));
 
     // The number of frames to generate
-    private static final int FRAMES_TO_GENERATE = 100;
+    private static final int FRAMES_TO_GENERATE = 100 ;
 
     // Dimensions of the viewport
     private static final int WIDTH = 1280;
@@ -91,7 +92,7 @@ public class Benchmark {
         System.out.println("Building world...");
         World world = new World();
         VectorFloat4 skybox = world.getSkyboxBuffer();
-        IntArray skyboxDimensions = new IntArray(world.getSkyboxDimensionsBuffer()[0], world.getSkyboxDimensionsBuffer()[1]);
+       IntArray skyboxDimensions = new IntArray(world.getSkyboxDimensionsBuffer()[0], world.getSkyboxDimensionsBuffer()[1]);
         VectorFloat4 bodyPositions = world.getBodyPositionsBuffer();
         VectorFloat bodySizes = world.getBodySizesBuffer();
         VectorFloat4 bodyColors = world.getBodyColorsBuffer();
@@ -149,12 +150,12 @@ public class Benchmark {
             // ==============================================================
             System.out.println("-----------------------------------------");
             System.out.println("Running [JAVA SEQUENTIAL]");
-            for (int i = 0; i < FRAMES_TO_GENERATE; i++) {
+                for (int i = 0; i < FRAMES_TO_GENERATE; i++) {
+                    Renderer.render(pixels, dimensions, camera, rayTracingProperties, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox, skyboxDimensions);
+                }
+                long startTime = System.nanoTime();
                 Renderer.render(pixels, dimensions, camera, rayTracingProperties, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox, skyboxDimensions);
-            }
-            long startTime = System.nanoTime();
-            Renderer.render(pixels, dimensions, camera, rayTracingProperties, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox, skyboxDimensions);
-            long endTime = System.nanoTime();
+                long endTime = System.nanoTime();
             sequentialTime = (endTime - startTime) / 1000000.0;
             System.out.println("Duration: " + sequentialTime + " ms");
         }

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -69,10 +69,10 @@ public class Benchmark {
      * Initialise rendering environment
      */
     private static void setRenderingProperties() {
-        dimensions = new IntArray(WIDTH, HEIGHT);
+        dimensions = IntArray.fromElements(WIDTH, HEIGHT);
         pixels = new IntArray(WIDTH * HEIGHT);
-        rayTracingProperties = new IntArray(SHADOW_SAMPLE_SIZE, REFLECTION_BOUNCES);
-        camera = new FloatArray(0, 0, -4F, 0, 0, 60);
+        rayTracingProperties = IntArray.fromElements(SHADOW_SAMPLE_SIZE, REFLECTION_BOUNCES);
+        camera = FloatArray.fromElements(0, 0, -4F, 0, 0, 60);
     }
 
     /**
@@ -89,7 +89,7 @@ public class Benchmark {
         System.out.println("Building world...");
         World world = new World();
         VectorFloat4 skybox = world.getSkyboxBuffer();
-        IntArray skyboxDimensions = new IntArray(world.getSkyboxDimensionsBuffer()[0], world.getSkyboxDimensionsBuffer()[1]);
+        IntArray skyboxDimensions = IntArray.fromElements(world.getSkyboxDimensionsBuffer()[0], world.getSkyboxDimensionsBuffer()[1]);
         VectorFloat4 bodyPositions = world.getBodyPositionsBuffer();
         VectorFloat bodySizes = world.getBodySizesBuffer();
         VectorFloat4 bodyColors = world.getBodyColorsBuffer();

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -26,7 +26,7 @@ import com.vinhderful.raytracer.renderer.Renderer;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.TornadoDriver;
-import uk.ac.manchester.tornado.api.TornadoRuntimeCI;
+import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
@@ -112,7 +112,7 @@ public class Benchmark {
         System.out.println("-----------------------------------------");
         System.out.println("Getting Tornado Devices...");
         ArrayList<TornadoDevice> devices = new ArrayList<>();
-        TornadoRuntimeCI runtimeCI = TornadoRuntime.getTornadoRuntime();
+        TornadoRuntimeInterface runtimeCI = TornadoRuntime.getTornadoRuntime();
         int numTornadoDrivers = runtimeCI.getNumDrivers();
         int deviceCount = 0;
 

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -25,7 +25,7 @@ import com.vinhderful.raytracer.renderer.Renderer;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskGraph;
-import uk.ac.manchester.tornado.api.TornadoDriver;
+import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -116,12 +116,12 @@ public class Benchmark {
         System.out.println("Getting Tornado Devices...");
         ArrayList<TornadoDevice> devices = new ArrayList<>();
         TornadoRuntimeInterface runtimeCI = TornadoRuntime.getTornadoRuntime();
-        int numTornadoDrivers = runtimeCI.getNumDrivers();
+        int numBackends = runtimeCI.getNumBackends();
         int deviceCount = 0;
 
-        for (int i = 0; i < numTornadoDrivers; i++) {
+        for (int i = 0; i < numBackends; i++) {
 
-            TornadoDriver driver = runtimeCI.getDriver(i);
+            TornadoBackend driver = runtimeCI.getBackend(i);
             int numDevices = driver.getDeviceCount();
 
             // Exclude PTX due to unsupported intrinsic (atan2)

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -98,7 +98,9 @@ public class Benchmark {
      */
     public static void main(String[] args) throws Exception {
 
-        setRenderingProperties();
+        setRenderingProperties(
+
+        );
 
         System.out.println("-----------------------------------------");
         System.out.println("Building world...");
@@ -221,10 +223,10 @@ public class Benchmark {
                     // ==============================================================
         System.out.println("-----------------------------------------");
         if (!SKIP_SEQUENTIAL) {
-                            System.out.println("Performance increase vs sequential: " + sequentialTime / tornadoTime + "x");
+            System.out.println("Performance increase vs sequential: " + sequentialTime / tornadoTime + "x");
         }
-                    System.out.println("Performance increase vs Java Streams: " + javaStreamsTime / tornadoTime + "x");
-                    System.out.println("-----------------------------------------");
+        System.out.println("Performance increase vs Java Streams: " + javaStreamsTime / tornadoTime + "x");
+        System.out.println("-----------------------------------------");
     }
 }
 }

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -34,6 +34,8 @@ import uk.ac.manchester.tornado.api.WorkerGrid2D;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
+import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 
@@ -59,20 +61,31 @@ public class Benchmark {
     private static final int REFLECTION_BOUNCES = 4;
 
     // Output and input buffers
-    private static int[] pixels;
-    private static float[] camera;
-    private static int[] dimensions;
-    private static int[] rayTracingProperties;
+    private static IntArray pixels;
+    private static FloatArray camera;
+    private static IntArray dimensions;
+    private static IntArray rayTracingProperties;
 
     /**
      * Initialise rendering environment
      */
     private static void setRenderingProperties() {
-        dimensions = new int[]{WIDTH, HEIGHT};
-        pixels = new int[WIDTH * HEIGHT];
+        dimensions = new IntArray(2);
+        pixels = new IntArray(WIDTH * HEIGHT);
+        rayTracingProperties = new IntArray(2);
 
-        camera = new float[]{0, 0, -4F, 0, 0, 60};
-        rayTracingProperties = new int[]{SHADOW_SAMPLE_SIZE, REFLECTION_BOUNCES};
+        rayTracingProperties.set(0,SHADOW_SAMPLE_SIZE);
+        rayTracingProperties.set(0,REFLECTION_BOUNCES);
+
+        dimensions.set(0, WIDTH);
+        dimensions.set(1, HEIGHT);
+
+
+        camera = new FloatArray(4);
+        camera.set(0,0);
+        camera.set(1,0);
+        camera.set(2,-4F);
+        camera.set(3,60);
     }
 
     /**
@@ -88,7 +101,10 @@ public class Benchmark {
         System.out.println("Building world...");
         World world = new World();
         VectorFloat4 skybox = world.getSkyboxBuffer();
-        int[] skyboxDimensions = world.getSkyboxDimensionsBuffer();
+//        int[] skyboxDimensions = world.getSkyboxDimensionsBuffer();
+        IntArray skyboxDimensions = new IntArray(2);
+        skyboxDimensions.set(0, world.getSkyboxDimensionsBuffer()[0]);
+        skyboxDimensions.set(1, world.getSkyboxDimensionsBuffer()[1]);
         VectorFloat4 bodyPositions = world.getBodyPositionsBuffer();
         VectorFloat bodySizes = world.getBodySizesBuffer();
         VectorFloat4 bodyColors = world.getBodyColorsBuffer();

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -30,13 +30,13 @@ import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
-import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
-import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
 
 /**
  * Benchmark class provides a no-GUI application to test the performance of the ray tracer when using hardware

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -71,23 +71,10 @@ public class Benchmark {
      * Initialise rendering environment
      */
     private static void setRenderingProperties() {
-        dimensions = new IntArray(2);
+        dimensions = new IntArray(WIDTH, HEIGHT);
         pixels = new IntArray(WIDTH * HEIGHT);
-        rayTracingProperties = new IntArray(2);
-
-        rayTracingProperties.set(0, SHADOW_SAMPLE_SIZE);
-        rayTracingProperties.set(0, REFLECTION_BOUNCES);
-
-        dimensions.set(0, WIDTH);
-        dimensions.set(1, HEIGHT);
-
-        camera = new FloatArray(6);
-        camera.set(0, 0);
-        camera.set(1, 0);
-        camera.set(2, -4F);
-        camera.set(3, 0);
-        camera.set(4, 0);
-        camera.set(5, 60);
+        rayTracingProperties = new IntArray(SHADOW_SAMPLE_SIZE, REFLECTION_BOUNCES);
+        camera = new FloatArray(0, 0, -4F, 0, 0, 60);
     }
 
     /**
@@ -98,18 +85,13 @@ public class Benchmark {
      */
     public static void main(String[] args) throws Exception {
 
-        setRenderingProperties(
-
-        );
+        setRenderingProperties();
 
         System.out.println("-----------------------------------------");
         System.out.println("Building world...");
         World world = new World();
         VectorFloat4 skybox = world.getSkyboxBuffer();
-        //        int[] skyboxDimensions = world.getSkyboxDimensionsBuffer();
-        IntArray skyboxDimensions = new IntArray(2);
-        skyboxDimensions.set(0, world.getSkyboxDimensionsBuffer()[0]);
-        skyboxDimensions.set(1, world.getSkyboxDimensionsBuffer()[1]);
+        IntArray skyboxDimensions = new IntArray(world.getSkyboxDimensionsBuffer()[0], world.getSkyboxDimensionsBuffer()[1]);
         VectorFloat4 bodyPositions = world.getBodyPositionsBuffer();
         VectorFloat bodySizes = world.getBodySizesBuffer();
         VectorFloat4 bodyColors = world.getBodyColorsBuffer();
@@ -183,15 +165,11 @@ public class Benchmark {
         System.out.println("-----------------------------------------");
         System.out.println("Running [JAVA PARALLEL STREAMS]");
 
-        for (int i = 0; i < FRAMES_TO_GENERATE; i++)
-            Renderer.renderWithParallelStreams(pixels, dimensions, camera, rayTracingProperties,
-                    bodyPositions, bodySizes, bodyColors, bodyReflectivities,
-                    skybox, skyboxDimensions);
-
+        for (int i = 0; i < FRAMES_TO_GENERATE; i++) {
+            Renderer.renderWithParallelStreams(pixels, dimensions, camera, rayTracingProperties, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox, skyboxDimensions);
+        }
         long startTime = System.nanoTime();
-                Renderer.renderWithParallelStreams(pixels, dimensions, camera, rayTracingProperties,
-                        bodyPositions, bodySizes, bodyColors, bodyReflectivities,
-                        skybox, skyboxDimensions);
+        Renderer.renderWithParallelStreams(pixels, dimensions, camera, rayTracingProperties, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox, skyboxDimensions);
         long endTime = System.nanoTime();
         double javaStreamsTime = (endTime - startTime) / 1000000.0;
         System.out.println("Duration: " + javaStreamsTime + " ms");

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -27,12 +27,12 @@ import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
-import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
+import uk.ac.manchester.tornado.api.TornadoRuntime;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
@@ -115,14 +115,14 @@ public class Benchmark {
         System.out.println("-----------------------------------------");
         System.out.println("Getting Tornado Devices...");
         ArrayList<TornadoDevice> devices = new ArrayList<>();
-        TornadoRuntimeInterface runtimeCI = TornadoRuntime.getTornadoRuntime();
-        int numBackends = runtimeCI.getNumBackends();
+        TornadoRuntime tornadoRuntime = TornadoRuntimeProvider.getTornadoRuntime();
+        int numBackends = tornadoRuntime.getNumBackends();
         int deviceCount = 0;
 
         for (int i = 0; i < numBackends; i++) {
 
-            TornadoBackend driver = runtimeCI.getBackend(i);
-            int numDevices = driver.getDeviceCount();
+            TornadoBackend driver = tornadoRuntime.getBackend(i);
+            int numDevices = driver.getNumDevices();
 
             // Exclude PTX due to unsupported intrinsic (atan2)
             if (driver.getName().toLowerCase().contains("ptx")) {

--- a/src/main/java/com/vinhderful/raytracer/Benchmark.java
+++ b/src/main/java/com/vinhderful/raytracer/Benchmark.java
@@ -124,11 +124,6 @@ public class Benchmark {
             TornadoBackend driver = tornadoRuntime.getBackend(i);
             int numDevices = driver.getNumDevices();
 
-            // Exclude PTX due to unsupported intrinsic (atan2)
-            if (driver.getName().toLowerCase().contains("ptx")) {
-                continue;
-            }
-
             for (int j = 0; j < numDevices; j++) {
                 TornadoDevice device = driver.getDevice(j);
                 devices.add(device);

--- a/src/main/java/com/vinhderful/raytracer/Settings.java
+++ b/src/main/java/com/vinhderful/raytracer/Settings.java
@@ -18,7 +18,7 @@
  */
 package com.vinhderful.raytracer;
 
-import uk.ac.manchester.tornado.api.collections.types.Float3;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 
 /**
  * Settings class contains variables users can tweak to change the rendering environment and the GUI

--- a/src/main/java/com/vinhderful/raytracer/controllers/About.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/About.java
@@ -36,7 +36,8 @@ public class About {
     /**
      * Open a given uri
      *
-     * @param uri uri string
+     * @param uri
+     *     uri string
      */
     private void openURL(String uri) {
         // TODO implement code to open URIs

--- a/src/main/java/com/vinhderful/raytracer/controllers/Loading.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Loading.java
@@ -18,7 +18,11 @@
  */
 package com.vinhderful.raytracer.controllers;
 
+import java.io.IOException;
+import java.util.Objects;
+
 import com.vinhderful.raytracer.App;
+
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -29,9 +33,6 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
-
-import java.io.IOException;
-import java.util.Objects;
 
 /**
  * Controller class for Loading window popping up while main program is loading
@@ -72,7 +73,8 @@ public class Loading {
         createMainWindow.setOnSucceeded(e -> {
             BorderPane root = (BorderPane) createMainWindow.getValue();
             Scene scene = null;
-            if (root != null) scene = new Scene(root);
+            if (root != null)
+                scene = new Scene(root);
 
             Stage stage = new Stage();
             stage.setTitle("TornadoVM Ray Tracer");

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -330,7 +330,7 @@ public class Main {
         WorkerGrid worker = new WorkerGrid2D(IB_dimensions.get(0), IB_dimensions.get(1));
         worker.setLocalWork(16, 16, 1);
         grid = new GridScheduler();
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
         executionPlan = new TornadoExecutionPlan(ts.snapshot());
     }
 

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -244,8 +244,8 @@ public class Main {
         setupRenderingEnvironment();
         System.out.println("Allocating buffers...");
         allocateBuffers();
-        System.out.println("Setting up Tornado Task Schedule...");
-        setupTornadoTaskSchedule();
+        System.out.println("Setting up Tornado Task Graph...");
+        setupTornadoTaskGraph();
         System.out.println("Getting Available Tornado Devices...");
         setAvailableDevices();
         System.out.println("Setting up operating loops...");
@@ -308,11 +308,11 @@ public class Main {
 
 
     /**
-     * Define Tornado task schedule for Parallel Renderer.render method
+     * Define Tornado task graph for Parallel Renderer.render method
      */
-    private void setupTornadoTaskSchedule() {
+    private void setupTornadoTaskGraph() {
 
-        // Define task schedule
+        // Define task graph
         ts = new TaskGraph("s0");
         ts.transferToDevice(DataTransferMode.EVERY_EXECUTION, IB_camera, IB_rayTracingProperties, IB_bodyPositions);
         ts.transferToDevice(DataTransferMode.FIRST_EXECUTION, IB_dimensions, IB_bodySizes, IB_bodyColors, IB_bodyReflectivities, IB_skybox, IB_skyboxDimensions);
@@ -600,7 +600,7 @@ public class Main {
             renderWithTornado = false;
             renderWithJavaStreams = true;
         } else if (selectedDeviceIndex > 1) {
-            // Map task schedule to selected device if selected device is tornado device
+            // Map task graph to selected device if selected device is tornado device
             TornadoDevice device = devices.get(selectedDeviceIndex - 1);
             shadowSampleSizeSlider.setMax(Settings.MAX_SHADOW_SAMPLE_SIZE);
             shadowSampleSizeSlider.setMajorTickUnit(50);

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -295,14 +295,10 @@ public class Main {
         OB_pixels = new IntArray(width * height);
 
         // Input buffers
-        IB_dimensions = new IntArray(2);
-        IB_dimensions.set(0, width);
-        IB_dimensions.set(0, height);
+        IB_dimensions = new IntArray(width, height);
         IB_camera = camera.getBuffer();
 
-        IB_rayTracingProperties = new IntArray(2);
-        IB_rayTracingProperties.set(0,shadowSampleSize );
-        IB_rayTracingProperties.set(1,reflectionBounces);
+        IB_rayTracingProperties = new IntArray(shadowSampleSize, reflectionBounces);
 
         IB_bodyPositions = world.getBodyPositionsBuffer();
         IB_bodySizes = world.getBodySizesBuffer();
@@ -310,9 +306,10 @@ public class Main {
         IB_bodyReflectivities = world.getBodyReflectivitiesBuffer();
 
         IB_skybox = world.getSkyboxBuffer();
-//        IB_skyboxDimensions = world.getSkyboxDimensionsBuffer();
-        IB_dimensions.set(0, world.getSkyboxDimensionsBuffer()[0]);
-        IB_dimensions.set(1, world.getSkyboxDimensionsBuffer()[1]);
+
+        IB_dimensions = new IntArray(world.getSkyboxDimensionsBuffer()[0],world.getSkyboxDimensionsBuffer()[1]);
+//        IB_skyboxDimensions.set(0, world.getSkyboxDimensionsBuffer()[0]);
+//        IB_skyboxDimensions.set(1, world.getSkyboxDimensionsBuffer()[1]);
     }
 
 
@@ -401,7 +398,11 @@ public class Main {
 
                 int[] temp =  new int[OB_pixels.getSize()];
 
-                temp = OB_pixels.getSegment().toArray(ValueLayout.JAVA_INT);
+                for (int i = 0; i < OB_pixels.getSize(); i++) {
+                    temp[i] = OB_pixels.get(i);
+                }
+
+//                temp = OB_pixels.getSegment().toArray(ValueLayout.JAVA_INT);
 
                 pixelWriter.setPixels(0, 0, width, height, format, temp, 0, width);
 

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -263,7 +263,7 @@ public class Main {
 
 
     /**
-     * Initialise canvas, dimensions, pixel writer, format, camera and ray tracing properties
+     * IInitialise canvas, dimensions, pixel writer, format, camera and ray tracing properties
      */
     private void setupRenderingEnvironment() {
 
@@ -307,9 +307,10 @@ public class Main {
 
         IB_skybox = world.getSkyboxBuffer();
 
-        IB_dimensions = new IntArray(world.getSkyboxDimensionsBuffer()[0],world.getSkyboxDimensionsBuffer()[1]);
-//        IB_skyboxDimensions.set(0, world.getSkyboxDimensionsBuffer()[0]);
-//        IB_skyboxDimensions.set(1, world.getSkyboxDimensionsBuffer()[1]);
+
+        IB_skyboxDimensions = new IntArray( world.getSkyboxDimensionsBuffer()[0],  world.getSkyboxDimensionsBuffer()[1]);
+
+
     }
 
 
@@ -402,7 +403,6 @@ public class Main {
                     temp[i] = OB_pixels.get(i);
                 }
 
-//                temp = OB_pixels.getSegment().toArray(ValueLayout.JAVA_INT);
 
                 pixelWriter.setPixels(0, 0, width, height, format, temp, 0, width);
 

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -41,7 +41,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskGraph;
-import uk.ac.manchester.tornado.api.TornadoDriver;
+import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -354,11 +354,11 @@ public class Main {
 
         // Get Tornado drivers
         TornadoRuntimeInterface runtimeCI = TornadoRuntime.getTornadoRuntime();
-        int numTornadoDrivers = runtimeCI.getNumDrivers();
+        int numBackends = runtimeCI.getNumBackends();
 
-        for (int i = 0; i < numTornadoDrivers; i++) {
+        for (int i = 0; i < numBackends; i++) {
 
-            TornadoDriver driver = runtimeCI.getDriver(i);
+            TornadoBackend driver = runtimeCI.getBackend(i);
             int numDevices = driver.getDeviceCount();
 
             // Add Tornado devices, perform initial mapping

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -335,7 +335,7 @@ public class Main {
         deviceDropdown.getItems().add("(Java Parallel Streams) - CPU");
 
         // Get Tornado drivers
-        TornadoRuntimeCI runtimeCI = TornadoRuntime.getTornadoRuntime();
+        TornadoRuntimeInterface runtimeCI = TornadoRuntime.getTornadoRuntime();
         int numTornadoDrivers = runtimeCI.getNumDrivers();
 
         for (int i = 0; i < numTornadoDrivers; i++) {

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -46,16 +46,16 @@ import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
-import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
-import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
+
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-import java.lang.foreign.ValueLayout;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/vinhderful/raytracer/controllers/Main.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Main.java
@@ -295,10 +295,10 @@ public class Main {
         OB_pixels = new IntArray(width * height);
 
         // Input buffers
-        IB_dimensions = new IntArray(width, height);
+        IB_dimensions = IntArray.fromElements(width, height);
         IB_camera = camera.getBuffer();
 
-        IB_rayTracingProperties = new IntArray(shadowSampleSize, reflectionBounces);
+        IB_rayTracingProperties = IntArray.fromElements(shadowSampleSize, reflectionBounces);
 
         IB_bodyPositions = world.getBodyPositionsBuffer();
         IB_bodySizes = world.getBodySizesBuffer();
@@ -308,7 +308,7 @@ public class Main {
         IB_skybox = world.getSkyboxBuffer();
 
 
-        IB_skyboxDimensions = new IntArray( world.getSkyboxDimensionsBuffer()[0],  world.getSkyboxDimensionsBuffer()[1]);
+        IB_skyboxDimensions = IntArray.fromElements( world.getSkyboxDimensionsBuffer()[0],  world.getSkyboxDimensionsBuffer()[1]);
 
 
     }

--- a/src/main/java/com/vinhderful/raytracer/controllers/Window.java
+++ b/src/main/java/com/vinhderful/raytracer/controllers/Window.java
@@ -18,7 +18,12 @@
  */
 package com.vinhderful.raytracer.controllers;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
+
 import com.vinhderful.raytracer.App;
+
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.fxml.FXMLLoader;
@@ -27,10 +32,6 @@ import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.Objects;
 
 /**
  * Helper class to encapsulate Controls and About windows
@@ -45,9 +46,12 @@ public class Window {
     /**
      * Instantiate a Window given a title, ray to the controlling FXML and ray to the icon
      *
-     * @param name    window title
-     * @param fxmlRay ray to FXML
-     * @param iconRay ray to icon
+     * @param name
+     *     window title
+     * @param fxmlRay
+     *     ray to FXML
+     * @param iconRay
+     *     ray to icon
      */
     public Window(String name, String fxmlRay, String iconRay) {
         this.name = name;
@@ -81,7 +85,8 @@ public class Window {
         loadTask.setOnSucceeded(e -> Platform.runLater(() -> {
             StackPane root = (StackPane) loadTask.getValue();
             Scene scene = null;
-            if (root != null) scene = new Scene(root);
+            if (root != null)
+                scene = new Scene(root);
 
             Stage stage = new Stage();
             stage.setTitle(name);

--- a/src/main/java/com/vinhderful/raytracer/misc/Camera.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Camera.java
@@ -81,7 +81,7 @@ public class Camera {
      * Allocate memory space and initialise the input buffer
      */
     private void allocateAndInitializeBuffer() {
-        buffer = new FloatArray(position.getX(), position.getY(), position.getZ(), yaw, pitch, fov);
+        buffer = FloatArray.fromElements(position.getX(), position.getY(), position.getZ(), yaw, pitch, fov);
     }
 
     /**

--- a/src/main/java/com/vinhderful/raytracer/misc/Camera.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Camera.java
@@ -21,6 +21,7 @@ package com.vinhderful.raytracer.misc;
 import com.vinhderful.raytracer.Settings;
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.collections.types.Float3;
+import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
 
 import static com.vinhderful.raytracer.utils.Angle.TO_RADIANS;
 import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
@@ -53,7 +54,7 @@ public class Camera {
     /**
      * The double buffer as input buffer for rendering
      */
-    private float[] buffer;
+    private FloatArray buffer;
 
     /**
      * Create a camera given a world to know where the plane height is,
@@ -79,7 +80,14 @@ public class Camera {
      * Allocate memory space and initialise the input buffer
      */
     private void allocateAndInitializeBuffer() {
-        buffer = new float[]{position.getX(), position.getY(), position.getZ(), yaw, pitch, fov};
+//        buffer = new float[]{position.getX(), position.getY(), position.getZ(), yaw, pitch, fov};
+        buffer = new FloatArray(6);
+        buffer.set(0,position.getX());
+        buffer.set(1, position.getY());
+        buffer.set(2,position.getZ());
+        buffer.set(3,yaw);
+        buffer.set(4,pitch);
+        buffer.set(5,fov);
     }
 
     /**
@@ -87,7 +95,7 @@ public class Camera {
      *
      * @return the pointer pointing to the input buffer array
      */
-    public float[] getBuffer() {
+    public FloatArray getBuffer() {
         return buffer;
     }
 
@@ -95,12 +103,12 @@ public class Camera {
      * Update the input buffer for rendering
      */
     public void updateBuffer() {
-        buffer[0] = position.getX();
-        buffer[1] = position.getY();
-        buffer[2] = position.getZ();
-        buffer[3] = yaw;
-        buffer[4] = pitch;
-        buffer[5] = fov;
+        buffer.set(0, position.getX());
+        buffer.set(1 , position.getY());
+        buffer.set(2 ,  position.getZ());
+        buffer.set(3, yaw);
+        buffer.set(4,  pitch);
+        buffer.set(5,  fov);
     }
 
     /**

--- a/src/main/java/com/vinhderful/raytracer/misc/Camera.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Camera.java
@@ -19,14 +19,13 @@
 package com.vinhderful.raytracer.misc;
 
 import static com.vinhderful.raytracer.utils.Angle.TO_RADIANS;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.min;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.max;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.min;
 
 import com.vinhderful.raytracer.Settings;
-
-import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
-import uk.ac.manchester.tornado.api.collections.types.Float3;
-import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 
 /**
  * Represents a scene camera with:

--- a/src/main/java/com/vinhderful/raytracer/misc/Camera.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Camera.java
@@ -80,14 +80,7 @@ public class Camera {
      * Allocate memory space and initialise the input buffer
      */
     private void allocateAndInitializeBuffer() {
-//        buffer = new float[]{position.getX(), position.getY(), position.getZ(), yaw, pitch, fov};
-        buffer = new FloatArray(6);
-        buffer.set(0,position.getX());
-        buffer.set(1, position.getY());
-        buffer.set(2,position.getZ());
-        buffer.set(3,yaw);
-        buffer.set(4,pitch);
-        buffer.set(5,fov);
+        buffer = new FloatArray(position.getX(), position.getY(), position.getZ(), yaw, pitch, fov);
     }
 
     /**
@@ -107,7 +100,7 @@ public class Camera {
         buffer.set(1 , position.getY());
         buffer.set(2 ,  position.getZ());
         buffer.set(3, yaw);
-        buffer.set(4,  pitch);
+        buffer.set(4, pitch);
         buffer.set(5,  fov);
     }
 

--- a/src/main/java/com/vinhderful/raytracer/misc/Camera.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Camera.java
@@ -18,14 +18,15 @@
  */
 package com.vinhderful.raytracer.misc;
 
-import com.vinhderful.raytracer.Settings;
-import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
-import uk.ac.manchester.tornado.api.collections.types.Float3;
-import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
-
 import static com.vinhderful.raytracer.utils.Angle.TO_RADIANS;
 import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
 import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.min;
+
+import com.vinhderful.raytracer.Settings;
+
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
+import uk.ac.manchester.tornado.api.collections.types.Float3;
+import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
 
 /**
  * Represents a scene camera with:
@@ -60,7 +61,8 @@ public class Camera {
      * Create a camera given a world to know where the plane height is,
      * camera will not be allowed to go under the plane
      *
-     * @param world the world containing the plane
+     * @param world
+     *     the world containing the plane
      */
     public Camera(World world) {
         position = Settings.INITIAL_CAMERA_POSITION;
@@ -97,11 +99,11 @@ public class Camera {
      */
     public void updateBuffer() {
         buffer.set(0, position.getX());
-        buffer.set(1 , position.getY());
-        buffer.set(2 ,  position.getZ());
+        buffer.set(1, position.getY());
+        buffer.set(2, position.getZ());
         buffer.set(3, yaw);
         buffer.set(4, pitch);
-        buffer.set(5,  fov);
+        buffer.set(5, fov);
     }
 
     /**
@@ -114,25 +116,29 @@ public class Camera {
         float _pitch = -pitch * TO_RADIANS;
 
         // Calculate forward pointing vector from yaw and pitch
-        Float3 fwdVector = Float3.normalise(new Float3(
-                TornadoMath.sin(_yaw) * TornadoMath.cos(_pitch),
-                        TornadoMath.sin(_pitch),
-                TornadoMath.cos(_yaw) * TornadoMath.cos(_pitch)));
+        Float3 fwdVector = Float3.normalise(new Float3(TornadoMath.sin(_yaw) * TornadoMath.cos(_pitch), TornadoMath.sin(_pitch), TornadoMath.cos(_yaw) * TornadoMath.cos(_pitch)));
 
         // Calculate left and right pointing vector from forward and up vectors
         Float3 leftVector = Float3.normalise(Float3.cross(fwdVector, upVector));
         Float3 rightVector = Float3.normalise(Float3.cross(upVector, fwdVector));
 
         // Depending on key pressed, update camera position
-        if (fwd) position = Float3.add(position, Float3.mult(fwdVector, moveSpeed));
-        if (back) position = Float3.sub(position, Float3.mult(fwdVector, moveSpeed));
-        if (strafeL) position = Float3.add(position, Float3.mult(leftVector, moveSpeed));
-        if (strafeR) position = Float3.add(position, Float3.mult(rightVector, moveSpeed));
-        if (up) position = Float3.add(position, Float3.mult(upVector, moveSpeed));
-        if (down) position = Float3.sub(position, Float3.mult(upVector, moveSpeed));
+        if (fwd)
+            position = Float3.add(position, Float3.mult(fwdVector, moveSpeed));
+        if (back)
+            position = Float3.sub(position, Float3.mult(fwdVector, moveSpeed));
+        if (strafeL)
+            position = Float3.add(position, Float3.mult(leftVector, moveSpeed));
+        if (strafeR)
+            position = Float3.add(position, Float3.mult(rightVector, moveSpeed));
+        if (up)
+            position = Float3.add(position, Float3.mult(upVector, moveSpeed));
+        if (down)
+            position = Float3.sub(position, Float3.mult(upVector, moveSpeed));
 
         // Limit camera to above plane
-        if (position.getY() < planeHeight) position.setY(planeHeight);
+        if (position.getY() < planeHeight)
+            position.setY(planeHeight);
     }
 
     /**
@@ -160,7 +166,8 @@ public class Camera {
     /**
      * Set the camera field of view to a given value
      *
-     * @param fov the desired fov value
+     * @param fov
+     *     the desired fov value
      */
     public void setFov(float fov) {
         this.fov = fov;

--- a/src/main/java/com/vinhderful/raytracer/misc/Physics.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Physics.java
@@ -18,12 +18,13 @@
  */
 package com.vinhderful.raytracer.misc;
 
-import com.vinhderful.raytracer.misc.bodies.Body;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import static com.vinhderful.raytracer.misc.World.SPHERES_START_INDEX;
 
 import java.util.ArrayList;
 
-import static com.vinhderful.raytracer.misc.World.SPHERES_START_INDEX;
+import com.vinhderful.raytracer.misc.bodies.Body;
+
+import uk.ac.manchester.tornado.api.collections.types.Float4;
 
 /**
  * The physics class includes logic for gravity and collision detection using the Verlet Integration.
@@ -50,7 +51,8 @@ public class Physics {
     /**
      * Construct a physics service given a world to operate on
      *
-     * @param world the world containing the spheres to perform physics calculations on
+     * @param world
+     *     the world containing the spheres to perform physics calculations on
      */
     public Physics(World world) {
         this.world = world;

--- a/src/main/java/com/vinhderful/raytracer/misc/Physics.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Physics.java
@@ -23,8 +23,7 @@ import static com.vinhderful.raytracer.misc.World.SPHERES_START_INDEX;
 import java.util.ArrayList;
 
 import com.vinhderful.raytracer.misc.bodies.Body;
-
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * The physics class includes logic for gravity and collision detection using the Verlet Integration.

--- a/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
@@ -18,14 +18,15 @@
  */
 package com.vinhderful.raytracer.misc;
 
-import com.vinhderful.raytracer.utils.Color;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
-import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Objects;
+
+import javax.imageio.ImageIO;
+
+import com.vinhderful.raytracer.utils.Color;
+
+import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 
 /**
  * Represents a spherical skybox initialised by image
@@ -38,7 +39,8 @@ public class Skybox {
     /**
      * Read the given resource into a BufferedImage
      *
-     * @param resourceName the ray to the resource
+     * @param resourceName
+     *     the ray to the resource
      */
     public Skybox(String resourceName) {
 
@@ -85,7 +87,7 @@ public class Skybox {
      * @return the dimensions int array containing [0] = width, [1] = height
      */
     public int[] getDimensionsBuffer() {
-        return new int[]{image.getWidth(), image.getHeight()};
+        return new int[] { image.getWidth(), image.getHeight() };
     }
 
 }

--- a/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
@@ -25,8 +25,7 @@ import java.util.Objects;
 import javax.imageio.ImageIO;
 
 import com.vinhderful.raytracer.utils.Color;
-
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
 
 /**
  * Represents a spherical skybox initialised by image

--- a/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
@@ -62,11 +62,12 @@ public class Skybox {
         int width = image.getWidth();
         int height = image.getHeight();
 
-        buffer = new VectorFloat4(width * height);
-
-        for (int x = 0; x < width; x++)
-            for (int y = 0; y < height; y++)
+        buffer = new VectorFloat4(width * height); // 8192 , 4096
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
                 buffer.set(x + y * width, Color.toFloat4(image.getRGB(x, y)));
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/Skybox.java
@@ -20,6 +20,7 @@ package com.vinhderful.raytracer.misc;
 
 import com.vinhderful.raytracer.utils.Color;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
+import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -85,4 +86,5 @@ public class Skybox {
     public int[] getDimensionsBuffer() {
         return new int[]{image.getWidth(), image.getHeight()};
     }
+
 }

--- a/src/main/java/com/vinhderful/raytracer/misc/World.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/World.java
@@ -18,22 +18,23 @@
  */
 package com.vinhderful.raytracer.misc;
 
-import com.vinhderful.raytracer.misc.bodies.Body;
-import com.vinhderful.raytracer.misc.bodies.Light;
-import com.vinhderful.raytracer.misc.bodies.Plane;
-import com.vinhderful.raytracer.misc.bodies.Sphere;
-import com.vinhderful.raytracer.utils.Color;
-import com.vinhderful.raytracer.utils.Float4Ext;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
-
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import com.vinhderful.raytracer.misc.bodies.Body;
+import com.vinhderful.raytracer.misc.bodies.Light;
+import com.vinhderful.raytracer.misc.bodies.Plane;
+import com.vinhderful.raytracer.misc.bodies.Sphere;
+import com.vinhderful.raytracer.utils.Color;
+import com.vinhderful.raytracer.utils.Float4Ext;
+
+import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
+import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 
 /**
  * A world representing objects in the scene
@@ -91,7 +92,8 @@ public class World {
     /**
      * Instantiate a default world
      *
-     * @throws Exception is thrown if light is not found at index 0 or plane is not found at index 1
+     * @throws Exception
+     *     is thrown if light is not found at index 0 or plane is not found at index 1
      */
     public World() throws Exception {
 
@@ -122,8 +124,10 @@ public class World {
     /**
      * Helper function to generate a random float value between min and max
      *
-     * @param min the minimum boundary of the random float
-     * @param max the maximum boundary of the random float
+     * @param min
+     *     the minimum boundary of the random float
+     * @param max
+     *     the maximum boundary of the random float
      * @return a random float between min and max
      */
     private float randFloat(float min, float max) {
@@ -133,8 +137,10 @@ public class World {
     /**
      * Helper function to generate a random position given a minimum and maximum coordinate value
      *
-     * @param min the minimum coordinate value
-     * @param max the maximum coordinate value
+     * @param min
+     *     the minimum coordinate value
+     * @param max
+     *     the maximum coordinate value
      * @return a random position bounded by min and max
      */
     private Float4 getRandomPosition(float min, float max) {
@@ -154,12 +160,12 @@ public class World {
         System.out.println("-> Adding object to the scene...");
 
         // Light
-            light = new Light(new Float4(0, 0, 0, 0), 1.2F, Color.WHITE);
-            addBody(light);
+        light = new Light(new Float4(0, 0, 0, 0), 1.2F, Color.WHITE);
+        addBody(light);
 
-            // Plane
-            plane = new Plane(24F, 36F);
-            addBody(plane);
+        // Plane
+        plane = new Plane(24F, 36F);
+        addBody(plane);
 
         // Spheres
         addBody(new Sphere(new Float4(-8, -8, 0, 0), 1.75F, Color.WHITE, 16));
@@ -194,7 +200,8 @@ public class World {
                             overlaps = true;
                             break;
                         }
-                    if (!overlaps) break;
+                    if (!overlaps)
+                        break;
                 }
             }
 
@@ -232,8 +239,10 @@ public class World {
      * Toggle between enabled/disabled physics
      */
     public void togglePhysics() {
-        if (physicsEnabled) disablePhysics();
-        else enablePhysics();
+        if (physicsEnabled)
+            disablePhysics();
+        else
+            enablePhysics();
     }
 
     /**
@@ -247,10 +256,10 @@ public class World {
         bodyPositions = new VectorFloat4(numBodies);
         bodySizes = new VectorFloat(numBodies);
         bodyColors = new VectorFloat4(numBodies);
-       bodyReflectivities = new VectorFloat(numBodies);
+        bodyReflectivities = new VectorFloat(numBodies);
 
         for (int i = 0; i < numBodies; i++) {
-           Body body = bodies.get(i);
+            Body body = bodies.get(i);
 
             bodyPositions.set(i, body.getPosition());
             bodySizes.set(i, body.getSize());
@@ -349,7 +358,8 @@ public class World {
     /**
      * Add a body to the world
      *
-     * @param body the body to add
+     * @param body
+     *     the body to add
      */
     private void addBody(Body body) {
         bodies.add(body);

--- a/src/main/java/com/vinhderful/raytracer/misc/World.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/World.java
@@ -154,12 +154,12 @@ public class World {
         System.out.println("-> Adding object to the scene...");
 
         // Light
-        light = new Light(new Float4(0, 0, 0, 0), 1.2F, Color.WHITE);
-        addBody(light);
+            light = new Light(new Float4(0, 0, 0, 0), 1.2F, Color.WHITE);
+            addBody(light);
 
-        // Plane
-        plane = new Plane(24F, 36F);
-        addBody(plane);
+            // Plane
+            plane = new Plane(24F, 36F);
+            addBody(plane);
 
         // Spheres
         addBody(new Sphere(new Float4(-8, -8, 0, 0), 1.75F, Color.WHITE, 16));
@@ -247,10 +247,10 @@ public class World {
         bodyPositions = new VectorFloat4(numBodies);
         bodySizes = new VectorFloat(numBodies);
         bodyColors = new VectorFloat4(numBodies);
-        bodyReflectivities = new VectorFloat(numBodies);
+       bodyReflectivities = new VectorFloat(numBodies);
 
         for (int i = 0; i < numBodies; i++) {
-            Body body = bodies.get(i);
+           Body body = bodies.get(i);
 
             bodyPositions.set(i, body.getPosition());
             bodySizes.set(i, body.getSize());

--- a/src/main/java/com/vinhderful/raytracer/misc/World.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/World.java
@@ -31,10 +31,9 @@ import com.vinhderful.raytracer.misc.bodies.Plane;
 import com.vinhderful.raytracer.misc.bodies.Sphere;
 import com.vinhderful.raytracer.utils.Color;
 import com.vinhderful.raytracer.utils.Float4Ext;
-
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * A world representing objects in the scene

--- a/src/main/java/com/vinhderful/raytracer/misc/bodies/Body.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/bodies/Body.java
@@ -18,7 +18,7 @@
  */
 package com.vinhderful.raytracer.misc.bodies;
 
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * Abstract class representing a solid body in a 3D space using its

--- a/src/main/java/com/vinhderful/raytracer/misc/bodies/Body.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/bodies/Body.java
@@ -37,10 +37,14 @@ public abstract class Body {
     /**
      * Create a body with given position, size, color and reflectivity
      *
-     * @param position     position represented by a vector in 3d space
-     * @param size         scale of the body
-     * @param color        color of the body represented by RGB values
-     * @param reflectivity reflectivity of the object
+     * @param position
+     *     position represented by a vector in 3d space
+     * @param size
+     *     scale of the body
+     * @param color
+     *     color of the body represented by RGB values
+     * @param reflectivity
+     *     reflectivity of the object
      */
     public Body(Float4 position, float size, Float4 color, float reflectivity) {
         this.position = position;
@@ -62,7 +66,8 @@ public abstract class Body {
     /**
      * Set the position of this body to a given value
      *
-     * @param position the value to set the position of this body to
+     * @param position
+     *     the value to set the position of this body to
      */
     public void setPosition(Float4 position) {
         this.position = position;
@@ -80,7 +85,8 @@ public abstract class Body {
     /**
      * Set the position of this body to a given value
      *
-     * @param position the value to set the position of this body to
+     * @param position
+     *     the value to set the position of this body to
      */
     public void setPreviousPosition(Float4 position) {
         this.previousPosition = position;

--- a/src/main/java/com/vinhderful/raytracer/misc/bodies/Light.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/bodies/Light.java
@@ -18,7 +18,7 @@
  */
 package com.vinhderful.raytracer.misc.bodies;
 
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * Represents a sphere light using position, radius and color

--- a/src/main/java/com/vinhderful/raytracer/misc/bodies/Plane.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/bodies/Plane.java
@@ -19,7 +19,7 @@
 package com.vinhderful.raytracer.misc.bodies;
 
 import com.vinhderful.raytracer.utils.Color;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * Represents a plane as the bottom side of a bounding box

--- a/src/main/java/com/vinhderful/raytracer/misc/bodies/Sphere.java
+++ b/src/main/java/com/vinhderful/raytracer/misc/bodies/Sphere.java
@@ -18,7 +18,7 @@
  */
 package com.vinhderful.raytracer.misc.bodies;
 
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * Represents a sphere using position, radius and color and reflectivity

--- a/src/main/java/com/vinhderful/raytracer/renderer/RayTracer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/RayTracer.java
@@ -18,17 +18,22 @@
  */
 package com.vinhderful.raytracer.renderer;
 
+import static com.vinhderful.raytracer.misc.World.LIGHT_INDEX;
+import static com.vinhderful.raytracer.misc.World.PLANE_INDEX;
+import static com.vinhderful.raytracer.renderer.Shader.AMBIENT_STRENGTH;
+import static com.vinhderful.raytracer.renderer.Shader.MAX_REFLECTIVITY;
+import static com.vinhderful.raytracer.renderer.Shader.getDiffuse;
+import static com.vinhderful.raytracer.renderer.Shader.getShadow;
+import static com.vinhderful.raytracer.renderer.Shader.getSpecular;
+import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
+
 import com.vinhderful.raytracer.utils.BodyOps;
 import com.vinhderful.raytracer.utils.Color;
+
 import uk.ac.manchester.tornado.api.collections.types.Float4;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
-
-import static com.vinhderful.raytracer.misc.World.LIGHT_INDEX;
-import static com.vinhderful.raytracer.misc.World.PLANE_INDEX;
-import static com.vinhderful.raytracer.renderer.Shader.*;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
 
 /**
  * The Ray Tracer class contains algorithms that bounce rays around the scene to gather color, shading and reflection
@@ -40,26 +45,36 @@ public class RayTracer {
      * Given a hit object and the ray that hit the object, bounce the ray according to the reflection bounce limit
      * around the scene to gather the color of the reflection
      *
-     * @param hitIndex              the index of the hit object
-     * @param hitPosition           the position of the hit object
-     * @param rayDirection          the ray's direction
-     * @param bodyPositions         the structure containing the positions of the objects in the scene
-     * @param bodySizes             the structure containing the sizes of the objects in the scene
-     * @param bodyColors            the structure containing the colors of the objects in the scene
-     * @param bodyReflectivities    the structure containing the reflectivities of the objects in the scene
-     * @param lightPosition         the position of the light source
-     * @param lightSize             the size of the light source
-     * @param skybox                the structure the colors of the skybox image
-     * @param skyboxDimensions      the structure the dimensions of the skybox image
-     * @param shadowSampleSize      the sample size to calculate soft shadows with
-     * @param reflectionBounceLimit the limit of how many times the reflection can bounce
+     * @param hitIndex
+     *     the index of the hit object
+     * @param hitPosition
+     *     the position of the hit object
+     * @param rayDirection
+     *     the ray's direction
+     * @param bodyPositions
+     *     the structure containing the positions of the objects in the scene
+     * @param bodySizes
+     *     the structure containing the sizes of the objects in the scene
+     * @param bodyColors
+     *     the structure containing the colors of the objects in the scene
+     * @param bodyReflectivities
+     *     the structure containing the reflectivities of the objects in the scene
+     * @param lightPosition
+     *     the position of the light source
+     * @param lightSize
+     *     the size of the light source
+     * @param skybox
+     *     the structure the colors of the skybox image
+     * @param skyboxDimensions
+     *     the structure the dimensions of the skybox image
+     * @param shadowSampleSize
+     *     the sample size to calculate soft shadows with
+     * @param reflectionBounceLimit
+     *     the limit of how many times the reflection can bounce
      * @return the color of the accumulated reflection
      */
-    public static Float4 getReflection(int hitIndex, Float4 hitPosition, Float4 rayDirection,
-                                       VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors, VectorFloat bodyReflectivities,
-                                       Float4 lightPosition, float lightSize,
-                                       VectorFloat4 skybox, IntArray skyboxDimensions,
-                                       int shadowSampleSize, int reflectionBounceLimit) {
+    public static Float4 getReflection(int hitIndex, Float4 hitPosition, Float4 rayDirection, VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors,
+            VectorFloat bodyReflectivities, Float4 lightPosition, float lightSize, VectorFloat4 skybox, IntArray skyboxDimensions, int shadowSampleSize, int reflectionBounceLimit) {
 
         // Initialise an empty reflection color, a contribution factor and shading factor
         Float4 reflectionColor = new Float4(0, 0, 0, 0);
@@ -132,24 +147,34 @@ public class RayTracer {
      * Given a hit object with its index, the hit position, the ray's origin and direction, return it's color after
      * calculating reflections and shading
      *
-     * @param hitIndex              the index of the hit object
-     * @param hitPosition           the position of the hit object
-     * @param rayOrigin             the ray's origin
-     * @param rayDirection          the ray's direction
-     * @param bodyPositions         the structure containing the positions of the objects in the scene
-     * @param bodySizes             the structure containing the sizes of the objects in the scene
-     * @param bodyColors            the structure containing the colors of the objects in the scene
-     * @param bodyReflectivities    the structure containing the reflectivities of the objects in the scene
-     * @param skybox                the structure the colors of the skybox image
-     * @param skyboxDimensions      the structure the dimensions of the skybox image
-     * @param shadowSampleSize      the sample size to calculate soft shadows with
-     * @param reflectionBounceLimit the limit of how many times the reflection can bounce
+     * @param hitIndex
+     *     the index of the hit object
+     * @param hitPosition
+     *     the position of the hit object
+     * @param rayOrigin
+     *     the ray's origin
+     * @param rayDirection
+     *     the ray's direction
+     * @param bodyPositions
+     *     the structure containing the positions of the objects in the scene
+     * @param bodySizes
+     *     the structure containing the sizes of the objects in the scene
+     * @param bodyColors
+     *     the structure containing the colors of the objects in the scene
+     * @param bodyReflectivities
+     *     the structure containing the reflectivities of the objects in the scene
+     * @param skybox
+     *     the structure the colors of the skybox image
+     * @param skyboxDimensions
+     *     the structure the dimensions of the skybox image
+     * @param shadowSampleSize
+     *     the sample size to calculate soft shadows with
+     * @param reflectionBounceLimit
+     *     the limit of how many times the reflection can bounce
      * @return the color of the hit object with shading and reflections applied
      */
-    public static Float4 getPixelColor(int hitIndex, Float4 hitPosition, Float4 rayOrigin, Float4 rayDirection,
-                                       VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors, VectorFloat bodyReflectivities,
-                                       VectorFloat4 skybox, IntArray skyboxDimensions,
-                                       int shadowSampleSize, int reflectionBounceLimit) {
+    public static Float4 getPixelColor(int hitIndex, Float4 hitPosition, Float4 rayOrigin, Float4 rayDirection, VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors,
+            VectorFloat bodyReflectivities, VectorFloat4 skybox, IntArray skyboxDimensions, int shadowSampleSize, int reflectionBounceLimit) {
 
         // Get the position and size of the light
         Float4 lightPosition = bodyPositions.get(LIGHT_INDEX);
@@ -161,10 +186,7 @@ public class RayTracer {
         float bodyReflectivity = bodyReflectivities.get(hitIndex);
 
         // Calculate the reflection color
-        Float4 reflectionColor = getReflection(hitIndex, hitPosition, rayDirection,
-                bodyPositions, bodySizes, bodyColors, bodyReflectivities,
-                lightPosition, lightSize,
-                skybox, skyboxDimensions,
+        Float4 reflectionColor = getReflection(hitIndex, hitPosition, rayDirection, bodyPositions, bodySizes, bodyColors, bodyReflectivities, lightPosition, lightSize, skybox, skyboxDimensions,
                 shadowSampleSize, reflectionBounceLimit);
 
         // Mix the object's color and the reflection color according to its reflectivity

--- a/src/main/java/com/vinhderful/raytracer/renderer/RayTracer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/RayTracer.java
@@ -23,6 +23,7 @@ import com.vinhderful.raytracer.utils.Color;
 import uk.ac.manchester.tornado.api.collections.types.Float4;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
+import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
 
 import static com.vinhderful.raytracer.misc.World.LIGHT_INDEX;
 import static com.vinhderful.raytracer.misc.World.PLANE_INDEX;
@@ -57,7 +58,7 @@ public class RayTracer {
     public static Float4 getReflection(int hitIndex, Float4 hitPosition, Float4 rayDirection,
                                        VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors, VectorFloat bodyReflectivities,
                                        Float4 lightPosition, float lightSize,
-                                       VectorFloat4 skybox, int[] skyboxDimensions,
+                                       VectorFloat4 skybox, IntArray skyboxDimensions,
                                        int shadowSampleSize, int reflectionBounceLimit) {
 
         // Initialise an empty reflection color, a contribution factor and shading factor
@@ -147,7 +148,7 @@ public class RayTracer {
      */
     public static Float4 getPixelColor(int hitIndex, Float4 hitPosition, Float4 rayOrigin, Float4 rayDirection,
                                        VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors, VectorFloat bodyReflectivities,
-                                       VectorFloat4 skybox, int[] skyboxDimensions,
+                                       VectorFloat4 skybox, IntArray skyboxDimensions,
                                        int shadowSampleSize, int reflectionBounceLimit) {
 
         // Get the position and size of the light

--- a/src/main/java/com/vinhderful/raytracer/renderer/RayTracer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/RayTracer.java
@@ -25,15 +25,14 @@ import static com.vinhderful.raytracer.renderer.Shader.MAX_REFLECTIVITY;
 import static com.vinhderful.raytracer.renderer.Shader.getDiffuse;
 import static com.vinhderful.raytracer.renderer.Shader.getShadow;
 import static com.vinhderful.raytracer.renderer.Shader.getSpecular;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.max;
 
 import com.vinhderful.raytracer.utils.BodyOps;
 import com.vinhderful.raytracer.utils.Color;
-
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
-import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * The Ray Tracer class contains algorithms that bounce rays around the scene to gather color, shading and reflection

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -213,7 +213,7 @@ public class Renderer {
                     // If the hit object is the light source, then simply paint the light source's color
                     // This will give a flat white circle is a white sphere light
                     if (hitIndex == LIGHT_INDEX) {
-                        pixels.set(x + y * width, Color.toInt(bodyColors.get(LIGHT_INDEX)));
+                        //pixels.set(x + y * width, Color.toInt(bodyColors.get(LIGHT_INDEX)));
                     }
 
                     // If the hit object is not a light source, then compute the pixel color after calculating

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -156,7 +156,7 @@ public class Renderer {
                     // If the hit object is the light source, then simply paint the light source's color
                     // This will give a flat white circle is a white sphere light
                     if (hitIndex == LIGHT_INDEX) {
-                        pixels.set(x + y * width,  Color.toInt(bodyColors.get(LIGHT_INDEX)));
+                        //pixels.set(x + y * width,  Color.toInt(bodyColors.get(LIGHT_INDEX)));
                     }
 
                     // If the hit object is not a light source, then compute the pixel color after calculating

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -110,8 +110,11 @@ public class Renderer {
         for (@Parallel int x = 0; x < width; x++)
             for (@Parallel int y = 0; y < height; y++) {
 
+                float normalizedX = getNormalizedX(width, height, x);
+                float normalizedY = getNormalizedY(width, height, y);
+
                 // Acquire the OpenGL-style coordinates of the pixel, where 0, 0 is the middle
-                Float4 normalizedCoords = new Float4(getNormalizedX(width, height, x), getNormalizedY(width, height, y), 0, 0);
+                Float4 normalizedCoords = new Float4(normalizedX, normalizedY, 0, 0);
 
                 // Acquire direction to each pixel by rotating it around the camera yaw and pitch
                 Float4 rayDirection = Float4Ext.rotate(Float4.normalise(Float4.sub(normalizedCoords, relativeCameraPosition)), camera[3], camera[4]);

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -28,12 +28,12 @@ import com.vinhderful.raytracer.utils.Color;
 import com.vinhderful.raytracer.utils.Float4Ext;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
-import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
-import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * The Renderer class contains the main parallelized render method

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -21,6 +21,8 @@ package com.vinhderful.raytracer.renderer;
 import static com.vinhderful.raytracer.misc.World.LIGHT_INDEX;
 import static com.vinhderful.raytracer.utils.Angle.TO_RADIANS;
 
+import java.util.stream.IntStream;
+
 import com.vinhderful.raytracer.utils.BodyOps;
 import com.vinhderful.raytracer.utils.Color;
 import com.vinhderful.raytracer.utils.Float4Ext;
@@ -33,8 +35,6 @@ import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
 import uk.ac.manchester.tornado.api.data.nativetypes.FloatArray;
 import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
 
-import java.util.stream.IntStream;
-
 /**
  * The Renderer class contains the main parallelized render method
  */
@@ -43,9 +43,12 @@ public class Renderer {
     /**
      * Calculate the OpenGL style x coordinate of the canvas, where (0, 0) is the middle of the screen
      *
-     * @param width  the width of the canvas
-     * @param height the height of the canvas
-     * @param x      the pixel's x coordinate
+     * @param width
+     *     the width of the canvas
+     * @param height
+     *     the height of the canvas
+     * @param x
+     *     the pixel's x coordinate
      * @return the normalized OpenGL-style x coordinate
      */
     public static float getNormalizedX(int width, int height, int x) {
@@ -58,9 +61,12 @@ public class Renderer {
     /**
      * Calculate the OpenGL style y coordinate of the canvas, where (0, 0) is the middle of the screen
      *
-     * @param width  the width of the canvas
-     * @param height the height of the canvas
-     * @param y      the pixel's y coordinate
+     * @param width
+     *     the width of the canvas
+     * @param height
+     *     the height of the canvas
+     * @param y
+     *     the pixel's y coordinate
      * @return the normalized OpenGL-style y coordinate
      */
     public static float getNormalizedY(int width, int height, int y) {
@@ -74,25 +80,34 @@ public class Renderer {
      * The main render function takes information from the INPUT BUFFERS, performs ray tracing and calculates an
      * INT_RGB value for each pixel writing to the OUTPUT BUFFER
      *
-     * @param pixels               OUTPUT BUFFER - int array of size width * height, where the calculated
-     *                             INT_RGB pixel colors are written
-     * @param dimensions           INPUT BUFFER - 2 element int array containing dimensions of the canvas
-     *                             0 - width; 1 - height
-     * @param camera               INPUT BUFFER - 6 element float array containing camera properties
-     *                             0, 1, 2 - x, y, z coordinates of position; 3, 4 - yaw, pitch; 5 - fov
-     * @param rayTracingProperties INPUT BUFFER - 2 element int array containing:
-     *                             0 - shadow sample size; 1 - reflection bounce limit
-     * @param bodyPositions        INPUT BUFFER - VectorFloat4 containing positions of the objects in the scene
-     * @param bodySizes            INPUT BUFFER - VectorFloat4 containing sizes of the objects in the scene
-     * @param bodyColors           INPUT BUFFER - VectorFloat4 containing colors of the objects in the scene
-     * @param bodyReflectivities   INPUT BUFFER - VectorFloat4 containing reflectivities of the objects in the scene
-     * @param skybox               INPUT BUFFER - VectorFloat4 representing the skybox colors
-     * @param skyboxDimensions     INPUT BUFFER - 2 element int array containing the dimensions of the skybox image
-     *                             0 - skybox image width; 1 - skybox image height
+     * @param pixels
+     *     OUTPUT BUFFER - int array of size width * height, where the calculated
+     *     INT_RGB pixel colors are written
+     * @param dimensions
+     *     INPUT BUFFER - 2 element int array containing dimensions of the canvas
+     *     0 - width; 1 - height
+     * @param camera
+     *     INPUT BUFFER - 6 element float array containing camera properties
+     *     0, 1, 2 - x, y, z coordinates of position; 3, 4 - yaw, pitch; 5 - fov
+     * @param rayTracingProperties
+     *     INPUT BUFFER - 2 element int array containing:
+     *     0 - shadow sample size; 1 - reflection bounce limit
+     * @param bodyPositions
+     *     INPUT BUFFER - VectorFloat4 containing positions of the objects in the scene
+     * @param bodySizes
+     *     INPUT BUFFER - VectorFloat4 containing sizes of the objects in the scene
+     * @param bodyColors
+     *     INPUT BUFFER - VectorFloat4 containing colors of the objects in the scene
+     * @param bodyReflectivities
+     *     INPUT BUFFER - VectorFloat4 containing reflectivities of the objects in the scene
+     * @param skybox
+     *     INPUT BUFFER - VectorFloat4 representing the skybox colors
+     * @param skyboxDimensions
+     *     INPUT BUFFER - 2 element int array containing the dimensions of the skybox image
+     *     0 - skybox image width; 1 - skybox image height
      */
-    public static void render(IntArray pixels, IntArray dimensions, FloatArray camera, IntArray rayTracingProperties,
-                              VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors, VectorFloat bodyReflectivities,
-                              VectorFloat4 skybox, IntArray skyboxDimensions) {
+    public static void render(IntArray pixels, IntArray dimensions, FloatArray camera, IntArray rayTracingProperties, VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors,
+            VectorFloat bodyReflectivities, VectorFloat4 skybox, IntArray skyboxDimensions) {
 
         // Relatively to the viewport, the camera will be placed in the middle, with exactly one unit of distance to
         // the viewport calculated by the field of view (camera[5] = fov)
@@ -133,18 +148,15 @@ public class Renderer {
                     // If the hit object is the light source, then simply paint the light source's color
                     // This will give a flat white circle is a white sphere light
                     if (hitIndex == LIGHT_INDEX) {
-                        pixels.set(x + y * width,  Color.toInt(bodyColors.get(LIGHT_INDEX)));
+                        //                        pixels.set(x + y * width,  Color.toInt(bodyColors.get(LIGHT_INDEX)));
                     }
 
                     // If the hit object is not a light source, then compute the pixel color after calculating
                     // shading reflections and shadows
                     else {
                         Float4 hitPosition = new Float4(hit.getX(), hit.getY(), hit.getZ(), 0);
-                        Float4 pixelColor = RayTracer.getPixelColor(
-                                hitIndex, hitPosition, cameraPosition, rayDirection,
-                                bodyPositions, bodySizes, bodyColors, bodyReflectivities,
-                                skybox, skyboxDimensions,
-                                shadowSampleSize, reflectionBounceLimit);
+                        Float4 pixelColor = RayTracer.getPixelColor(hitIndex, hitPosition, cameraPosition, rayDirection, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox,
+                                skyboxDimensions, shadowSampleSize, reflectionBounceLimit);
 
                         pixels.set(x + y * width, Color.toInt(pixelColor));
                     }
@@ -157,9 +169,8 @@ public class Renderer {
             }
     }
 
-    public static void renderWithParallelStreams(IntArray pixels, IntArray dimensions, FloatArray camera, IntArray rayTracingProperties,
-                              VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors, VectorFloat bodyReflectivities,
-                              VectorFloat4 skybox, IntArray skyboxDimensions) {
+    public static void renderWithParallelStreams(IntArray pixels, IntArray dimensions, FloatArray camera, IntArray rayTracingProperties, VectorFloat4 bodyPositions, VectorFloat bodySizes,
+            VectorFloat4 bodyColors, VectorFloat bodyReflectivities, VectorFloat4 skybox, IntArray skyboxDimensions) {
 
         // Relatively to the viewport, the camera will be placed in the middle, with exactly one unit of distance to
         // the viewport calculated by the field of view (camera[5] = fov)
@@ -201,11 +212,8 @@ public class Renderer {
                     // shading reflections and shadows
                     else {
                         Float4 hitPosition = new Float4(hit.getX(), hit.getY(), hit.getZ(), 0);
-                        Float4 pixelColor = RayTracer.getPixelColor(
-                                hitIndex, hitPosition, cameraPosition, rayDirection,
-                                bodyPositions, bodySizes, bodyColors, bodyReflectivities,
-                                skybox, skyboxDimensions,
-                                shadowSampleSize, reflectionBounceLimit);
+                        Float4 pixelColor = RayTracer.getPixelColor(hitIndex, hitPosition, cameraPosition, rayDirection, bodyPositions, bodySizes, bodyColors, bodyReflectivities, skybox,
+                                skyboxDimensions, shadowSampleSize, reflectionBounceLimit);
 
                         pixels.set(x + y * width, Color.toInt(pixelColor));
                     }

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -97,7 +97,9 @@ public class Renderer {
         // Relatively to the viewport, the camera will be placed in the middle, with exactly one unit of distance to
         // the viewport calculated by the field of view (camera[5] = fov)
         // https://docs.microsoft.com/en-us/windows/win32/direct3d9/viewports-and-clipping
-        Float4 relativeCameraPosition = new Float4(0, 0, -1 / TornadoMath.tan(camera.get(5) * 0.5F * TO_RADIANS), 0);
+        float relativeValue = -1 / TornadoMath.tan(camera.get(5) * 0.5F * TO_RADIANS);
+
+        Float4 relativeCameraPosition = new Float4(0, 0, relativeValue, 0);
         Float4 cameraPosition = new Float4(camera.get(0), camera.get(1), camera.get(2), 0);
 
         // Get dimensions of the viewport

--- a/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Renderer.java
@@ -106,8 +106,16 @@ public class Renderer {
      *     INPUT BUFFER - 2 element int array containing the dimensions of the skybox image
      *     0 - skybox image width; 1 - skybox image height
      */
-    public static void render(IntArray pixels, IntArray dimensions, FloatArray camera, IntArray rayTracingProperties, VectorFloat4 bodyPositions, VectorFloat bodySizes, VectorFloat4 bodyColors,
-            VectorFloat bodyReflectivities, VectorFloat4 skybox, IntArray skyboxDimensions) {
+    public static void render(IntArray pixels,
+                              IntArray dimensions,
+                              FloatArray camera,
+                              IntArray rayTracingProperties,
+                              VectorFloat4 bodyPositions,
+                              VectorFloat bodySizes,
+                              VectorFloat4 bodyColors,
+                              VectorFloat bodyReflectivities,
+                              VectorFloat4 skybox,
+                              IntArray skyboxDimensions) {
 
         // Relatively to the viewport, the camera will be placed in the middle, with exactly one unit of distance to
         // the viewport calculated by the field of view (camera[5] = fov)
@@ -148,7 +156,7 @@ public class Renderer {
                     // If the hit object is the light source, then simply paint the light source's color
                     // This will give a flat white circle is a white sphere light
                     if (hitIndex == LIGHT_INDEX) {
-                        //                        pixels.set(x + y * width,  Color.toInt(bodyColors.get(LIGHT_INDEX)));
+                        pixels.set(x + y * width,  Color.toInt(bodyColors.get(LIGHT_INDEX)));
                     }
 
                     // If the hit object is not a light source, then compute the pixel color after calculating

--- a/src/main/java/com/vinhderful/raytracer/renderer/Shader.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Shader.java
@@ -18,17 +18,18 @@
  */
 package com.vinhderful.raytracer.renderer;
 
+import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.floatPI;
+import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
+import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.pow;
+
 import com.vinhderful.raytracer.utils.BodyOps;
 import com.vinhderful.raytracer.utils.Color;
 import com.vinhderful.raytracer.utils.Float4Ext;
+
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.collections.types.Float4;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
-
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.floatPI;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.pow;
 
 /**
  * The Shader class contains operations to perform Blinn-Phong shading, calculating reflections and soft shadows
@@ -60,7 +61,6 @@ public class Shader {
      */
     public static final float MAX_REFLECTIVITY = 128F;
 
-
     /**
      * Given a ray and a hit object, mix ambient, diffuse and specular lighting to create a 3D shaded appearance
      * for the given object and return the color at the hit position
@@ -68,19 +68,24 @@ public class Shader {
      * https://learnopengl.com/Lighting/Basic-Lighting
      * https://learnopengl.com/Advanced-Lighting/Advanced-Lighting
      *
-     * @param hitIndex         the index of the hit object
-     * @param hitPosition      the position of the hit
-     * @param rayOrigin        the ray's origin
-     * @param bodyPosition     the position of the hit object
-     * @param bodyColor        the color of the hit object
-     * @param bodyReflectivity the reflectivity/shininess of the hit object
-     * @param lightPosition    the position of the light
+     * @param hitIndex
+     *     the index of the hit object
+     * @param hitPosition
+     *     the position of the hit
+     * @param rayOrigin
+     *     the ray's origin
+     * @param bodyPosition
+     *     the position of the hit object
+     * @param bodyColor
+     *     the color of the hit object
+     * @param bodyReflectivity
+     *     the reflectivity/shininess of the hit object
+     * @param lightPosition
+     *     the position of the light
      * @return a Float4 containing the color of the object at the given hit position after applying the Blinn-Phong
-     * shading model
+     *     shading model
      */
-    public static Float4 getBlinnPhong(int hitIndex, Float4 hitPosition, Float4 rayOrigin,
-                                       Float4 bodyPosition, Float4 bodyColor, float bodyReflectivity,
-                                       Float4 lightPosition) {
+    public static Float4 getBlinnPhong(int hitIndex, Float4 hitPosition, Float4 rayOrigin, Float4 bodyPosition, Float4 bodyColor, float bodyReflectivity, Float4 lightPosition) {
 
         // Ambient and diffuse lighting
         float diffuse = max(AMBIENT_STRENGTH, getDiffuse(hitIndex, hitPosition, bodyPosition, lightPosition));
@@ -92,18 +97,21 @@ public class Shader {
         return Color.mult(Color.add(bodyColor, specular), diffuse);
     }
 
-
     /**
      * Given hit object and the light position, apply diffuse shading according to the Blinn-Phong model and return the
      * diffuse factor of the object at the hit position
      * https://learnopengl.com/Lighting/Basic-Lighting
      *
-     * @param hitIndex      the index of the hit object
-     * @param hitPosition   the position of the hit
-     * @param bodyPosition  the position of the hit object
-     * @param lightPosition the position of the light
+     * @param hitIndex
+     *     the index of the hit object
+     * @param hitPosition
+     *     the position of the hit
+     * @param bodyPosition
+     *     the position of the hit object
+     * @param lightPosition
+     *     the position of the light
      * @return a float containing the diffuse factor of the object at the given position - i.e. how dark the object
-     * is at the position according to the light
+     *     is at the position according to the light
      */
     public static float getDiffuse(int hitIndex, Float4 hitPosition, Float4 bodyPosition, Float4 lightPosition) {
 
@@ -117,24 +125,27 @@ public class Shader {
         return Float4.dot(hitNormal, lightDirection);
     }
 
-
     /**
      * Given hit object, the ray and the light position, apply specular shading according to the Blinn-Phong model and
      * return the specular factor of the object at the hit position
      * https://learnopengl.com/Advanced-Lighting/Advanced-Lighting
      *
-     * @param hitIndex         the index of the hit object
-     * @param hitPosition      the position of the hit
-     * @param rayOrigin        the ray's origin
-     * @param bodyPosition     the position of the hit object
-     * @param bodyReflectivity the reflectivity/shininess of the hit object
-     * @param lightPosition    the position of the light
+     * @param hitIndex
+     *     the index of the hit object
+     * @param hitPosition
+     *     the position of the hit
+     * @param rayOrigin
+     *     the ray's origin
+     * @param bodyPosition
+     *     the position of the hit object
+     * @param bodyReflectivity
+     *     the reflectivity/shininess of the hit object
+     * @param lightPosition
+     *     the position of the light
      * @return a float containing the specular factor of the object at the given position - i.e. how bright the specular
-     * highlight is at the position according to the light
+     *     highlight is at the position according to the light
      */
-    public static float getSpecular(int hitIndex, Float4 hitPosition, Float4 rayOrigin,
-                                    Float4 bodyPosition, float bodyReflectivity,
-                                    Float4 lightPosition) {
+    public static float getSpecular(int hitIndex, Float4 hitPosition, Float4 rayOrigin, Float4 bodyPosition, float bodyReflectivity, Float4 lightPosition) {
 
         // Calculate direction to the camera and to the light
         Float4 viewDirection = Float4.normalise(Float4.sub(rayOrigin, hitPosition));
@@ -163,17 +174,22 @@ public class Shader {
      * This sphere is uniformly sampled using the sunflower seed arrangement/vogel spiral phenomenon:
      * https://www.codeproject.com/Articles/1221341/The-Vogel-Spiral-Phenomenon
      *
-     * @param hitPosition   the position of the hit
-     * @param bodyPositions the structure representing the positions of the objects in the scene
-     * @param bodySizes     the structure representing the sizes of the objects in the scene
-     * @param lightPosition the position of the light
-     * @param lightSize     the size of the light
-     * @param sampleSize    how many samples to take from the light for the soft shadow effect
+     * @param hitPosition
+     *     the position of the hit
+     * @param bodyPositions
+     *     the structure representing the positions of the objects in the scene
+     * @param bodySizes
+     *     the structure representing the sizes of the objects in the scene
+     * @param lightPosition
+     *     the position of the light
+     * @param lightSize
+     *     the size of the light
+     * @param sampleSize
+     *     how many samples to take from the light for the soft shadow effect
      * @return a float factor that determines how dark the hit object should be at the hit position according to
-     * the cast shadows
+     *     the cast shadows
      */
-    public static float getShadow(Float4 hitPosition, VectorFloat4 bodyPositions, VectorFloat bodySizes,
-                                  Float4 lightPosition, float lightSize, int sampleSize) {
+    public static float getShadow(Float4 hitPosition, VectorFloat4 bodyPositions, VectorFloat bodySizes, Float4 lightPosition, float lightSize, int sampleSize) {
 
         // Get a main shadow feeler ray direction from the hit position to the light
         Float4 n = Float4.normalise(Float4.sub(hitPosition, lightPosition));
@@ -211,7 +227,9 @@ public class Shader {
         }
 
         // Calculate soft shadows according to how many of the sampled shadow feelers hit an object
-        if (raysHit == 0) return 1;
-        else return 1 - (float) raysHit / (sampleSize * (1 + SHADOW_BRIGHTNESS));
+        if (raysHit == 0)
+            return 1;
+        else
+            return 1 - (float) raysHit / (sampleSize * (1 + SHADOW_BRIGHTNESS));
     }
 }

--- a/src/main/java/com/vinhderful/raytracer/renderer/Shader.java
+++ b/src/main/java/com/vinhderful/raytracer/renderer/Shader.java
@@ -18,18 +18,18 @@
  */
 package com.vinhderful.raytracer.renderer;
 
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.floatPI;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.pow;
 
 import com.vinhderful.raytracer.utils.BodyOps;
 import com.vinhderful.raytracer.utils.Color;
 import com.vinhderful.raytracer.utils.Float4Ext;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.floatPI;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.max;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.pow;
 
 /**
  * The Shader class contains operations to perform Blinn-Phong shading, calculating reflections and soft shadows

--- a/src/main/java/com/vinhderful/raytracer/utils/Angle.java
+++ b/src/main/java/com/vinhderful/raytracer/utils/Angle.java
@@ -18,7 +18,7 @@
  */
 package com.vinhderful.raytracer.utils;
 
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.floatPI;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
 
 /**
  * Represents helper variables to compute operations with angles
@@ -28,5 +28,5 @@ public class Angle {
     /**
      * Multiply a degree value with this constant to get the equivalent radians value
      */
-    public static final float TO_RADIANS = floatPI() / 180;
+    public static final float TO_RADIANS = TornadoMath.floatPI() / 180;
 }

--- a/src/main/java/com/vinhderful/raytracer/utils/BodyOps.java
+++ b/src/main/java/com/vinhderful/raytracer/utils/BodyOps.java
@@ -22,6 +22,7 @@ import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.collections.types.Float4;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
 import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
+import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
 
 import static com.vinhderful.raytracer.misc.World.*;
 import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.abs;
@@ -251,7 +252,7 @@ public class BodyOps {
      * @param direction        the direction from the sphere origin to the surface
      * @return the UV-mapped color of the skybox at in the specified direction
      */
-    public static Float4 getSkyboxColor(VectorFloat4 skybox, int[] skyBoxDimensions, Float4 direction) {
+    public static Float4 getSkyboxColor(VectorFloat4 skybox, IntArray skyBoxDimensions, Float4 direction) {
 
         // Convert unit vector to texture coordinates
         // https://en.wikipedia.org/wiki/UV_mapping#Finding_UV_on_a_sphere
@@ -259,8 +260,8 @@ public class BodyOps {
         float v = 0.5F - TornadoMath.asin(direction.getY()) / floatPI();
 
         // Get color from the skybox VectorFloat4
-        int x = (int) (u * (skyBoxDimensions[0] - 1));
-        int y = (int) (v * (skyBoxDimensions[1] - 1));
-        return skybox.get(x + y * skyBoxDimensions[0]);
+        int x = (int) (u * (skyBoxDimensions.get(0) - 1));
+        int y = (int) (v * (skyBoxDimensions.get(1) - 1));
+        return skybox.get(x + y * skyBoxDimensions.get(0));
     }
 }

--- a/src/main/java/com/vinhderful/raytracer/utils/BodyOps.java
+++ b/src/main/java/com/vinhderful/raytracer/utils/BodyOps.java
@@ -18,18 +18,12 @@
  */
 package com.vinhderful.raytracer.utils;
 
-import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat;
-import uk.ac.manchester.tornado.api.collections.types.VectorFloat4;
-import uk.ac.manchester.tornado.api.data.nativetypes.IntArray;
-
-import static com.vinhderful.raytracer.misc.World.*;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.abs;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.floatPI;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.floor;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.min;
+import com.vinhderful.raytracer.misc.World;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
  * Operations on the objects in the scene
@@ -59,7 +53,7 @@ public class BodyOps {
         final Float4 NO_INTERSECTION = new Float4(-1F, -1F, -1F, -1F);
 
         // Light
-        if (hitIndex == LIGHT_INDEX) {
+        if (hitIndex == World.LIGHT_INDEX) {
 
             Float4 min = Float4.sub(position, size * 0.5F);
             Float4 max = Float4.add(position, size * 0.5F);
@@ -75,8 +69,8 @@ public class BodyOps {
             float t5 = (min.getZ() - rayOrigin.getZ()) * dZ;
             float t6 = (max.getZ() - rayOrigin.getZ()) * dZ;
 
-            float tMin = max(max(min(t1, t2), min(t3, t4)), min(t5, t6));
-            float tMax = min(min(max(t1, t2), max(t3, t4)), max(t5, t6));
+            float tMin = TornadoMath.max(TornadoMath.max(TornadoMath.min(t1, t2), TornadoMath.min(t3, t4)), TornadoMath.min(t5, t6));
+            float tMax = TornadoMath.min(TornadoMath.min(TornadoMath.max(t1, t2), TornadoMath.max(t3, t4)), TornadoMath.max(t5, t6));
 
             if (tMax < 0 || tMin > tMax)
                 return NO_INTERSECTION;
@@ -88,11 +82,11 @@ public class BodyOps {
         }
 
         // Plane
-        else if (hitIndex == PLANE_INDEX) {
+        else if (hitIndex == World.PLANE_INDEX) {
             float t = -(rayOrigin.getY() - position.getY()) / rayDirection.getY();
             if (t > 0 && Float.isFinite(t)) {
                 Float4 intersection = Float4.add(rayOrigin, Float4.mult(rayDirection, t));
-                if (abs(intersection.getX()) > size * 0.5F || abs(intersection.getZ()) > size * 0.5F)
+                if (TornadoMath.abs(intersection.getX()) > size * 0.5F || TornadoMath.abs(intersection.getZ()) > size * 0.5F)
                     return NO_INTERSECTION;
                 else
                     return intersection;
@@ -141,7 +135,7 @@ public class BodyOps {
         boolean intersects = false;
 
         // Loop over objects in the scene, excluding light and plane, break out of loop when intersection is found
-        for (int i = SPHERES_START_INDEX; i < bodyPositions.getLength() && !intersects; i++) {
+        for (int i = World.SPHERES_START_INDEX; i < bodyPositions.getLength() && !intersects; i++) {
 
             // Calculate the intersection of the ray with the current object
             Float4 intersection = BodyOps.getIntersection(i, bodyPositions.get(i), bodySizes.get(i), rayOrigin, rayDirection);
@@ -209,7 +203,7 @@ public class BodyOps {
     public static Float4 getNormal(int hitIndex, Float4 position, Float4 point) {
 
         // Plane normal is an up vector in the y direction
-        if (hitIndex == PLANE_INDEX) {
+        if (hitIndex == World.PLANE_INDEX) {
             return new Float4(0, 1F, 0, 0);
         }
 
@@ -229,9 +223,9 @@ public class BodyOps {
     public static Float4 getColor(int hitIndex, Float4 point, VectorFloat4 bodyColors) {
 
         // Get checkerboard pattern for plane
-        if (hitIndex == PLANE_INDEX) {
+        if (hitIndex == World.PLANE_INDEX) {
 
-            if ((int) (floor(point.getX()) + floor(point.getZ())) % 2 == 0)
+            if ((int) (TornadoMath.floor(point.getX()) + TornadoMath.floor(point.getZ())) % 2 == 0)
                 // GRAY
                 return new Float4(0.4F, 0.4F, 0.4F, 0);
             else
@@ -256,8 +250,8 @@ public class BodyOps {
 
         // Convert unit vector to texture coordinates
         // https://en.wikipedia.org/wiki/UV_mapping#Finding_UV_on_a_sphere
-        float u = 0.5F + TornadoMath.atan2(direction.getZ(), direction.getX()) / (2 * floatPI());
-        float v = 0.5F - TornadoMath.asin(direction.getY()) / floatPI();
+        float u = 0.5F + TornadoMath.atan2(direction.getZ(), direction.getX()) / (2 * TornadoMath.floatPI());
+        float v = 0.5F - TornadoMath.asin(direction.getY()) / TornadoMath.floatPI();
 
         // Get color from the skybox VectorFloat4
         int x = (int) (u * (skyBoxDimensions.get(0) - 1));

--- a/src/main/java/com/vinhderful/raytracer/utils/Color.java
+++ b/src/main/java/com/vinhderful/raytracer/utils/Color.java
@@ -18,10 +18,10 @@
  */
 package com.vinhderful.raytracer.utils;
 
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.max;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.min;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.max;
+import static uk.ac.manchester.tornado.api.math.TornadoMath.min;
 
 /**
  * Color definitions and operations, a color is represented by RGB float values in a Float4, where

--- a/src/main/java/com/vinhderful/raytracer/utils/Float4Ext.java
+++ b/src/main/java/com/vinhderful/raytracer/utils/Float4Ext.java
@@ -18,8 +18,8 @@
  */
 package com.vinhderful.raytracer.utils;
 
-import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
-import uk.ac.manchester.tornado.api.collections.types.Float4;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 import static com.vinhderful.raytracer.utils.Angle.TO_RADIANS;
 


### PR DESCRIPTION
TornadoVM as from https://github.com/Vinhixus/TornadoVM-Ray-Tracer/commit/2e5184f8b5c2bef4e8503ae0f83d0695db6300a7 will migrate to use off-heap memory types through the Panama API.

This PR modifies Ray-Tracer to be compatible with the new data-API on TornadoVM.